### PR TITLE
add context method param; fix ssh key handling for CloudInit

### DIFF
--- a/api/code/src/main/python/stratuslab/Runnable.py
+++ b/api/code/src/main/python/stratuslab/Runnable.py
@@ -82,6 +82,10 @@ class Runnable(AuthnCommand):
                                help='extra context string (separate by %s)' % Util.cliLineSplitChar,
                                default=default_options['extraContextData'])
 
+        self.parser.add_option('--context-method', dest='defaultContextMethod', metavar='METHOD',
+                               help='default contextualization method (one or cloud-init)',
+                               default=default_options['defaultContextMethod'])
+
         self.parser.add_option('--cloud-init', dest='cloudInit', metavar='PAIRS',
                                help='mimetype,file pairs (separate by %s)' % Util.cliLineSplitChar,
                                default=default_options['cloudInit'])

--- a/api/code/src/main/python/stratuslab/vm_manager/Runner.py
+++ b/api/code/src/main/python/stratuslab/vm_manager/Runner.py
@@ -98,7 +98,7 @@ class Runner(VmManager):
         self.rawData = ''
         self.extraContextFile = ''
         self.extraContextData = ''
-        self.cloudInit = ''
+        self.cloudInit = None
         self.vncPort = ''
         self.vncListen = ''
         self.noCheckImageUrl = False
@@ -314,7 +314,7 @@ class Runner(VmManager):
                      'isPrivateIp': False,
                      'extraContextFile': '',
                      'extraContextData': '',
-                     'cloudInit': '',
+                     'cloudInit': None,
                      # FIXME: hack to fix a weird problem with network in CentOS on Fedora 14 + KVM.
                      #        Network is not starting unless VNC is defined. Weird yeh...? 8-/
                      'vncPort': '-1',
@@ -451,9 +451,12 @@ class Runner(VmManager):
         if self.extraContextData:
             contextElems.extend(self.extraContextData.split(Util.cliLineSplitChar))
 
-        if self.cloudInit:
+        if self.cloudInit or (self.defaultContextMethod and self.defaultContextMethod == 'cloud-init'):
+            if self.cloudInit is None:
+                self.cloudInit = ''
+
             cloudInitArgs = self.cloudInit.split(Util.cliLineSplitChar)
-            cloudInitData = CloudInitUtil.context_file(cloudInitArgs)
+            cloudInitData = CloudInitUtil.context_file(cloudInitArgs, default_public_key_file=self.userPublicKeyFile)
             contextElems.extend(cloudInitData.split('\n'))
 
         for line in contextElems:

--- a/api/code/src/main/python/stratuslab/vm_manager/vm_manager.py
+++ b/api/code/src/main/python/stratuslab/vm_manager/vm_manager.py
@@ -65,14 +65,12 @@ class VmManager(object):
         self.vm_image = image
         self.configHolder = config_holder
 
-
     @staticmethod
     def getTemplatePath(instance=None):
         if instance and hasattr(instance, 'vmTemplateFile'):
             return Util.get_share_file(['vm', 'schema.one'], instance.vmTemplateFile)
         else:
             return Util.get_share_file(['vm', 'schema.one'])
-
 
     @staticmethod
     def getDefaultInstanceTypes():
@@ -116,7 +114,8 @@ class VmManager(object):
                            'isPrivateIp': False,
                            'extraContextFile': '',
                            'extraContextData': '',
-                           'cloudInit': '',
+                           'cloudInit': None,
+                           'defaultContextMethod': 'one',
                            # FIXME: hack to fix a weird problem with network in CentOS on Fedora 14 + KVM.
                            #        Network is not starting unless VNC is defined. Weird yeh...? 8-/
                            'vncPort': '-1',

--- a/api/code/src/main/resources/conf/stratuslab-user.cfg.ref
+++ b/api/code/src/main/resources/conf/stratuslab-user.cfg.ref
@@ -44,6 +44,13 @@ pdisk_endpoint = https://cloud.example.com/pdisk
 username = username
 password = password
 
+#
+# Contextualization method
+#   one = OpenNebula/HEPiX (default)
+#   cloud-init = CloudInit contextualization
+#
+# default_context_method = cloud-init
+
 # Certificate or proxy credentials.
 # Use same value for both parameters for a proxy certificate.
 #


### PR DESCRIPTION
Add a `default_context_method` parameter to the user configuration file.  Setting this to 'cloud-init' will use CloudInit contextualization by default. 

This pull request also fixes handling of the SSH keys when using CloudInit.  If the SSH key isn't specified in the `--cloud-init` option, then the default SSH public key will be used.
