### PR TITLE
Provide root disk size with the VM template

### DIFF
--- a/api/code/src/main/python/stratuslab/CloudInfo.py
+++ b/api/code/src/main/python/stratuslab/CloudInfo.py
@@ -35,9 +35,17 @@ class CloudInfo(object):
             for child in children:
                 self._populate(child, _parentHierachy)
         else:
-            # skip the root element
-            hierachy = parentHierachy[1:] + [element.tag]
-            attributeName = '_'.join(hierachy)
+            # root element is not included
+            if parentHierachy[-1].tag == 'DISK':
+                try:
+                    disk_id = parentHierachy[-1].find('DISK_ID').text
+                except Exception:
+                    disk_id = 'X'
+                hierachy = [e.tag for e in parentHierachy[1:]] + [disk_id, element.tag]
+                attributeName = '_'.join(hierachy)
+            else:
+                hierachy = parentHierachy[1:] + [element]
+                attributeName = '_'.join([e.tag for e in hierachy])
             if isinstance(element.text, unicode):
                 text = element.text.encode('utf-8')
             else:
@@ -50,7 +58,7 @@ class CloudInfo(object):
     
     def _updateHierachy(self, element, parentHierachy):
         _parentHierachy = parentHierachy[:]
-        _parentHierachy.append(element.tag)
+        _parentHierachy.append(element)
         return _parentHierachy
 
     def getAttributes(self):

--- a/api/code/src/main/python/stratuslab/image/Image.py
+++ b/api/code/src/main/python/stratuslab/image/Image.py
@@ -68,6 +68,9 @@ class Image(object):
     def getInboundPortsByImageId(self, imageId):
         return self._getImageElementValue('inboundports', imageId)
 
+    def get_image_size_by_image_id(self, image_id):
+        return self._getImageElementValue('bytes', image_id)
+
     def _getImageElementValue(self, element, imageId):
         if Image.isImageId(imageId):
             return self.manifestDownloader.getImageElementValue(element, imageId)

--- a/api/code/src/main/resources/share/vm/schema.one
+++ b/api/code/src/main/resources/share/vm/schema.one
@@ -12,6 +12,7 @@ source   = "%(vm_image)s",
 target   = "%(vm_disks_prefix)sa",
 save     = %(save_disk)s,
 readonly = "no",
+%(root_disk_size_entry)s
 driver = "%(disk_driver)s"
 ]
 DISK = [

--- a/api/code/src/test/python/CloudInfoTest.py
+++ b/api/code/src/test/python/CloudInfoTest.py
@@ -58,5 +58,33 @@ class VmInfoTest(unittest.TestCase):
         self.assertEqual('ID3',info.level1_level2_level3_id3)
         self.assertEqual('ID4',info.level1_id4)
 
+    def test_disk_element(self):
+        xml = '''
+<root>
+    <level1>
+        <id1>ID1</id1>
+        <DISK>
+            <DISK_ID>0</DISK_ID>
+            <SIZE>123</SIZE>
+        </DISK>
+        <DISK>
+            <SIZE>456</SIZE>
+        </DISK>
+    </level1>
+</root>
+'''
+        root = etree.fromstring(xml)
+
+        info = CloudInfo()
+        info.populate(root)
+
+        assert hasattr(info, 'level1_disk_0_disk_id')
+        assert hasattr(info, 'level1_disk_0_size')
+        assert hasattr(info, 'level1_disk_x_size')
+        assert '0' == info.level1_disk_0_disk_id
+        assert '123' == info.level1_disk_0_size
+        assert '456' == info.level1_disk_x_size
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/api/code/src/test/python/vm_manager/RunnerTest.py
+++ b/api/code/src/test/python/vm_manager/RunnerTest.py
@@ -99,6 +99,12 @@ class RunnerTest(unittest.TestCase):
     def tearDown(self):
         reload(ConfigHolder)
 
+    def test_set_root_disk_size(self):
+        runner = self._getRunnerForManifest(self.MANIFEST_DISKS_BUS_VIRTIO,
+                                            'MMZu9WvwKIro-rtBQfDk4PsKO7_')
+        vm_params = runner._vmParamDict()
+        self.failUnlessEqual('size = 0,', vm_params['root_disk_size_entry'])
+
     def testDisksBusTypeVirtio(self):
         runner = self._getRunnerForManifest(self.MANIFEST_DISKS_BUS_VIRTIO,
                                             'MMZu9WvwKIro-rtBQfDk4PsKO7_')


### PR DESCRIPTION
- provide root disk size with the VM template
- updated `CloudInfo` class to take into account template's `DISK` element hierarchy when building VM representation

Connected to #159 
